### PR TITLE
Fix: Load CORS origins from environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,26 @@ API_PORT=8000
 API_DEBUG=True
 
 # CrewAI Configuration
-OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY="your_openai_api_key"
+
+# OpenAI Base URL (Optional, for custom endpoints like LiteLLM proxy)
+# OPENAI_API_BASE="http://localhost:8000"
+
+# OpenAI Model Name (Optional, defaults to o3-mini if not set)
+# OPENAI_MODEL_NAME="gpt-4-turbo"
+
+# VirusTotal API Key (Required for ThreatIntelAgent)
+VIRUSTOTAL_API_KEY="your_virustotal_api_key"
+
+# OpenTelemetry Endpoint (Optional, for exporting traces/metrics)
+# OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 
 # Security
 CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+
+# Allowed CORS Origins (Required for API, comma-separated)
+# Example: ALLOWED_ORIGINS="http://localhost:3000,https://yourfrontend.com"
+ALLOWED_ORIGINS=""
 
 # Logging
 LOG_LEVEL=INFO

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,6 @@
 """Main FastAPI application module."""
 
+import os # Import os to access environment variables
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +9,16 @@ from api.routers import agents
 
 # Load environment variables
 load_dotenv()
+
+# Get allowed origins from environment variable
+# Expects a comma-separated string, e.g., "http://localhost:3000,https://myapp.com"
+allowed_origins_str = os.getenv("ALLOWED_ORIGINS", "")
+allowed_origins = [origin.strip() for origin in allowed_origins_str.split(",") if origin.strip()] 
+# Default to empty list if variable is not set or empty, which is safer than ["*"]
+if not allowed_origins:
+    # You might want to log a warning here in a real application
+    # print("Warning: ALLOWED_ORIGINS environment variable not set. CORS will be restrictive.")
+    pass # Keep allowed_origins as []
 
 # Create FastAPI app
 app = FastAPI(
@@ -19,10 +30,10 @@ app = FastAPI(
 # Configure CORS
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # In production, replace with specific origins
+    allow_origins=allowed_origins, # Use the variable here
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["*"], # Consider restricting methods (e.g., ["GET", "POST"]) in production
+    allow_headers=["*"], # Consider restricting headers in production
 )
 
 # Include routers


### PR DESCRIPTION
## Description
This PR modifies the FastAPI application to load allowed CORS origins from the `ALLOWED_ORIGINS` environment variable instead of using a hardcoded wildcard (`"*"`). This improves security and configuration management.

## Changes Made
- Updated `api/main.py` to use `os.getenv("ALLOWED_ORIGINS", "")` to fetch origins.
- Origins are parsed from a comma-separated string.
- If the environment variable is not set or empty, `allow_origins` defaults to an empty list (`[]`), which is more restrictive than the previous wildcard.
- Added `ALLOWED_ORIGINS` to `.env.example`.

## Related Issues
- Addresses the `python.fastapi.security.wildcard-cors.wildcard-cors` finding from Semgrep. 